### PR TITLE
refactor : 문의글 생성 URI 변경

### DIFF
--- a/src/main/java/com/example/puddingbe/domain/inquiry/presentation/InquiryController.java
+++ b/src/main/java/com/example/puddingbe/domain/inquiry/presentation/InquiryController.java
@@ -53,7 +53,7 @@ public class InquiryController {
         inquiryDeleteService.deleteInquiry(id);
     }
 
-    @PostMapping
+    @PostMapping("/create")
     @ResponseStatus(HttpStatus.CREATED)
     public void createInquiry(@RequestBody InquiryRequest request) {
         inquiryCreateService.createInquiry(request);

--- a/src/main/java/com/example/puddingbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/puddingbe/global/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -55,7 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/inquiry/{inquiry-id}").authenticated()
                         .requestMatchers(HttpMethod.POST, "/inquiry/{inquiry-id}/reply").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/inquiry/{inquiry-id}").authenticated()
-                        .requestMatchers(HttpMethod.POST, "/inquiry").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/inquiry/create").authenticated()
 
                         // ranking API
                         .requestMatchers(HttpMethod.GET, "/ranking/global").permitAll()


### PR DESCRIPTION
클라이언트 요구사항에 따른 수정
문의글 생성과 어드민의 전체 문의 조회 둘 다 /inquiry 사용
-> 문의글 생성을 /inquiry/create로 변경 (api 명세서 수정 완료)